### PR TITLE
Change the function name of getRequirements with getRequirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ After the transaction is registered, other wallet owners can confirm this transa
 
 Below is the list of read-only methods. By calling these methods, you can get information from the wallet.
 
-#### getRequirements
+#### getRequirement
 
 Returns the requirements value.
 
 ```python
 @external(readonly=True)
-def getRequirements(self) -> int:
+def getRequirement(self) -> int:
 ```
 
 **Example**
@@ -73,7 +73,7 @@ def getRequirements(self) -> int:
         "to": "cx30d7fcf580135d9f9eb491292555a5b29d9314cb",
         "dataType": "call",
         "data": {           
-            "method": "getRequirements",
+            "method": "getRequirement",
             "params": {}
         }
     }

--- a/multisig_wallet/multisig_wallet.py
+++ b/multisig_wallet/multisig_wallet.py
@@ -301,7 +301,7 @@ class MultiSigWallet(IconScoreBase, IconScoreException):
         self.RequirementChange(_required)
 
     @external(readonly=True)
-    def getRequirements(self) -> int:
+    def getRequirement(self) -> int:
         return self._required.get()
 
     @external(readonly=True)

--- a/tests/test_integrate_base.py
+++ b/tests/test_integrate_base.py
@@ -182,7 +182,7 @@ class TestIntegrateBase(TestCase):
             "to": multisig_score_addr,
             "dataType": "call",
             "data": {
-                "method": "getRequirements",
+                "method": "getRequirement",
                 "params": {}
             }
         }
@@ -239,7 +239,7 @@ class TestIntegrateBase(TestCase):
             "to": multisig_score_addr,
             "dataType": "call",
             "data": {
-                "method": "getRequirements",
+                "method": "getRequirement",
                 "params": {}
             }
         }

--- a/tests/test_integrate_confirm_transaction.py
+++ b/tests/test_integrate_confirm_transaction.py
@@ -142,7 +142,7 @@ class TestIntegrateConfirmTransaction(TestIntegrateBase):
             "to": self.multisig_score_addr,
             "dataType": "call",
             "data": {
-                "method": "getRequirements",
+                "method": "getRequirement",
                 "params": {}
             }
         }

--- a/tests/test_integrate_wallet_method.py
+++ b/tests/test_integrate_wallet_method.py
@@ -561,7 +561,7 @@ class TestIntegrateWalletMethod(TestIntegrateBase):
             "to": self.multisig_score_addr,
             "dataType": "call",
             "data": {
-                "method": "getRequirements",
+                "method": "getRequirement",
                 "params": {}
             }
         }
@@ -601,7 +601,7 @@ class TestIntegrateWalletMethod(TestIntegrateBase):
             "to": self.multisig_score_addr,
             "dataType": "call",
             "data": {
-                "method": "getRequirements",
+                "method": "getRequirement",
                 "params": {}
             }
         }
@@ -641,7 +641,7 @@ class TestIntegrateWalletMethod(TestIntegrateBase):
             "to": self.multisig_score_addr,
             "dataType": "call",
             "data": {
-                "method": "getRequirements",
+                "method": "getRequirement",
                 "params": {}
             }
         }


### PR DESCRIPTION
Since the requirement is singular, getRequirement is more appropriate.