### PR TITLE
Implement transaction class without struct package

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ Below is an example of a `addWalletOwner` method call. After writing the request
 
 #### confirmTransaction
 
-Confirms a transaction corresponding to the `_transactionId`. As soon as a transaction confirmation count meets the 'requirement' value(should not exceed), the transaction is executed. Only wallet owners can call this method.
+Confirms a transaction corresponding to the `_transactionId`. As soon as a transaction confirmation count meets the 'requirement' value (should not exceed), the transaction is executed. Only wallet owners can call this method.
 
 ```python
 @external

--- a/multisig_wallet/multisig_wallet.py
+++ b/multisig_wallet/multisig_wallet.py
@@ -161,6 +161,7 @@ class MultiSigWallet(IconScoreBase, IconScoreException):
         self._wallet_owner_exist(self.msg.sender)
         # prevent failure of executing transaction caused by 'params' conversion problems
         self._check_params_format_convertible(_params)
+        self._only_positive_number(_value)
 
         # add transaction
         transaction_id = self._add_transaction(_destination, _method, _params, _value, _description)

--- a/multisig_wallet/multisig_wallet.py
+++ b/multisig_wallet/multisig_wallet.py
@@ -191,11 +191,11 @@ class MultiSigWallet(IconScoreBase, IconScoreException):
         self.Revocation(self.msg.sender, _transactionId)
 
     def _add_transaction(self, destination: Address, method: str, params: str, value: int, description: str) -> int:
-        transaction = Transaction(destination=destination,
-                                  method=method,
-                                  params=params,
-                                  value=value,
-                                  description=description)
+        transaction = Transaction.create_transaction_with_validation(destination=destination,
+                                                                     method=method,
+                                                                     params=params,
+                                                                     value=value,
+                                                                     description=description)
         transaction_id = self._transaction_count.get()
 
         self._transactions[transaction_id] = transaction.to_bytes()

--- a/multisig_wallet/transaction.py
+++ b/multisig_wallet/transaction.py
@@ -105,14 +105,14 @@ class Transaction:
 
     @classmethod
     def from_bytes(cls, buf: bytes):
-        encoded_executed = buf[0]
+        encoded_executed = bool(buf[0])
         encoded_destination = buf[1: 1 + ADDRESS_BYTE_LEN]
         encoded_value = buf[1 + ADDRESS_BYTE_LEN: 1 + ADDRESS_BYTE_LEN + DEFAULT_VALUE_BYTES]
         flexible_vars_json_string = buf[1 + ADDRESS_BYTE_LEN + DEFAULT_VALUE_BYTES:].decode()
         flexible_vars_json = json_loads(flexible_vars_json_string)
 
         return cls(executed=encoded_executed,
-                   destination=Address.from_bytes(encoded_destination.strip(b'\x00')),
+                   destination=Address.from_bytes(encoded_destination),
                    value=int.from_bytes(encoded_value, DATA_BYTE_ORDER),
                    method=flexible_vars_json["method"],
                    params=flexible_vars_json["params"],
@@ -122,7 +122,8 @@ class Transaction:
         encoded_executed = self.executed.to_bytes(1, DATA_BYTE_ORDER)
         encoded_value = self.value.to_bytes(DEFAULT_VALUE_BYTES, DATA_BYTE_ORDER)
         destination_bytes = self.destination.to_bytes()
-        destination_bytes = destination_bytes if len(destination_bytes) == 21 else b'\x00' + destination_bytes
+        destination_bytes = destination_bytes if len(destination_bytes) == ADDRESS_BYTE_LEN \
+            else b'\x00' + destination_bytes
 
         flexible_vars = dict()
         flexible_vars["method"] = self.method

--- a/tests/test_integrate_send_icx.py
+++ b/tests/test_integrate_send_icx.py
@@ -41,6 +41,25 @@ class TestIntegrateSendIcx(TestIntegrateBase):
         response = self._query(query_request, 'icx_getBalance')
         self.assertEqual(send_icx_value, response)
 
+    def test_send_icx_negative_value(self):
+        # failure case: submit transaction which send -10 icx to token score
+        submit_tx_params = {'_destination': str(self.token_score_addr),
+                            '_description': 'send negative icx value',
+                            '_value': f'{hex(-10*ICX_FACTOR)}'}
+
+        submit_tx = self._make_score_call_tx(addr_from=self._owner1,
+                                             addr_to=self.multisig_score_addr,
+                                             method='submitTransaction',
+                                             params=submit_tx_params
+                                             )
+        prev_block, tx_results = self._make_and_req_block([submit_tx])
+        self._write_precommit_state(prev_block)
+        self.assertEqual(tx_results[0].status, int(False))
+
+        expected_revert_massage = 'only positive number is accepted'
+        actual_revert_massage = tx_results[0].failure.message
+        self.assertEqual(expected_revert_massage, actual_revert_massage)
+
     def test_send_icx_to_score(self):
         # success case: send icx to SCORE(token score)
 


### PR DESCRIPTION
Modify Transaction class (#12)
- Implement Transaction class without struct package.
- Add create_transaction_with_validation method: this method is used only when submitTransaction is called. 
Fix some minor typos
