### PR TITLE
Supplement the contents of the document and unify the exception codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,15 +499,15 @@ Submits a transaction which is to be executed when the number of confirmations m
 def submitTransaction(self, _destination: Address, _method: str="", _params: str="", _value: int=0, _description: str=""):
 ```
 
-`_destination` is the SCORE address in which `_method` is defined in. 
+`_destination` is the SCORE address where `_method` is defined.
 
-`_description` is a detailed description of the transaction. This parameter is optional.
+`_description` is a supplementary explanation of the transaction. (optional parameter)
 
-`_value` is amount of ICX coin in loop (1 ICX == 1 ^ 18 loop). This parameter is used when transferring ICX coin or calling 'payable' method (i.e. optional parameter). 
+`_value` is amount of ICX coin in loop (1 ICX == 1 ^ 18 loop). This parameter is used when transferring ICX coin or calling 'payable' method. (optional parameter)
 
-`_method` is the name of the method that is to be executed when the number of confirmations meets the 'requirement' value. In the case of transferring ICX coin, do not have to input this parameter (i.e. optional parameter).
+`_method` is the name of the method that is to be executed when the number of confirmations meets the 'requirement' value. In the case of transferring ICX coin, do not have to specify this parameter. (optional parameter)
 
-`_params` is a stringified JSON data. This data is used as the arguments of the `_method` when it is executed. Below is the format. **name** is parameter's name, **type** is parameter's type (supported types are `int`, `str`, `bool`, `Address` and `bytes`), **value** is the actual data. In the case of transferring ICX coin, do not have to input this parameter (i.e. optional parameter).
+`_params` is a stringified JSON data. This data is used as the arguments of the `_method` when it is executed. Below is the format. **name** is parameter's name, **type** is parameter's type (supported types are `int`, `str`, `bool`, `Address` and `bytes`), **value** is the actual data. In the case of transferring ICX coin, do not have to specify this parameter. (optional parameter)
 
 
 ![](./images/submitTransaction_json_format.png)
@@ -741,7 +741,7 @@ def revokeTransaction(self, _transactionId: int):
 
 
 
-### Methods (only called by wallet)
+### Methods (only callable by wallet)
 
 These methods only can be called by the multisig wallet SCORE itself. **In short, you can not call those methods directly (or it will fail)**. If you want to execute these methods, call `submitTransaction` with the method's information as a parameter.
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ If you want to use funds (e.g., send ICX or token) or change the internally set 
 ```json
 {
     "_destination": "hx7f39710d3718e7d1f307d7c71755fbbe76be3c71",
-    "_method": "",
-    "_params": "",
     "_description": "send 10 icx to owner1",
     "_value": "0x8ac7230489e80000"
 }
@@ -503,13 +501,13 @@ def submitTransaction(self, _destination: Address, _method: str="", _params: str
 
 `_destination` is the SCORE address in which `_method` is defined in. 
 
-`_description` is a detailed description of the transaction.
+`_description` is a detailed description of the transaction. This parameter is optional.
 
-`_value` is amount of ICX coin in loop (1 ICX == 1 ^ 18 loop).
+`_value` is amount of ICX coin in loop (1 ICX == 1 ^ 18 loop). This parameter is used when transferring ICX coin or calling 'payable' method (i.e. optional parameter). 
 
-`_method` is the name of the method that is to be executed when the number of confirmations meets the 'requirement' value.
+`_method` is the name of the method that is to be executed when the number of confirmations meets the 'requirement' value. In the case of transferring ICX coin, do not have to input this parameter (i.e. optional parameter).
 
-`_params` is a stringified JSON data. This data is used as the arguments of the `_method` when it is executed. Below is the format. **name** is parameter's name, **type** is parameter's type (supported types are `int`, `str`, `bool`, `Address` and `bytes`), **value** is the actual data.
+`_params` is a stringified JSON data. This data is used as the arguments of the `_method` when it is executed. Below is the format. **name** is parameter's name, **type** is parameter's type (supported types are `int`, `str`, `bool`, `Address` and `bytes`), **value** is the actual data. In the case of transferring ICX coin, do not have to input this parameter (i.e. optional parameter).
 
 
 ![](./images/submitTransaction_json_format.png)

--- a/multisig_wallet/multisig_wallet.py
+++ b/multisig_wallet/multisig_wallet.py
@@ -19,7 +19,7 @@ from .qualification_check.qualification_check import *
 from .transaction import Transaction
 
 
-class MultiSigWallet(IconScoreBase, IconScoreException):
+class MultiSigWallet(IconScoreBase):
     _MAX_WALLET_OWNER_COUNT = 50
     _MAX_DATA_REQUEST_AMOUNT = 50
 
@@ -82,8 +82,8 @@ class MultiSigWallet(IconScoreBase, IconScoreException):
         self._check_requirement(len(wallet_owner_list), _required)
 
         for wallet_owner in wallet_owner_list:
-            wallet_owner_addr = Address.from_string(wallet_owner)
-            self._wallet_owners.put(wallet_owner_addr)
+            wallet_owner_address = Address.from_string(wallet_owner)
+            self._wallet_owners.put(wallet_owner_address)
 
         self._required.set(_required)
         self._transaction_count.set(0)
@@ -91,7 +91,8 @@ class MultiSigWallet(IconScoreBase, IconScoreException):
     def on_update(self) -> None:
         super().on_update()
 
-    def _check_params_format_convertible(self, json_formatted_params: str):
+    @staticmethod
+    def _check_params_format_convertible(json_formatted_params: str):
         # when user input None as a _params' value,
         # this will be changed to "" when creating Transaction instance.
         # "" will be changed to {} when finally execute transaction. so doesn't check format
@@ -101,49 +102,50 @@ class MultiSigWallet(IconScoreBase, IconScoreException):
                 for param in params:
                     params_type_converter(param["type"], param["value"])
             except ValueError as e:
-                self.revert(f"json format error: {e}")
+                revert(f"json format error: {e}")
             except IconScoreException as e:
-                self.revert(f"{e}")
+                revert(f"{e}")
             except:
-                self.revert(f"can't convert 'params' json data, check the 'params' parameter")
+                revert("can't convert 'params' json data, check the 'params' parameter")
 
-    def _only_positive_number(self, *args):
+    @staticmethod
+    def _only_positive_number(*args):
         for number in args:
             if number < 0:
-                raise IconScoreException(f"only positive number is accepted")
+                revert("only positive number is accepted")
 
     def _wallet_owner_does_not_exist(self, wallet_owner: Address):
         if wallet_owner in self._wallet_owners:
-            self.revert(f"{wallet_owner} already exists as an owner of the wallet")
+            revert(f"{wallet_owner} already exists as an owner of the wallet")
 
     def _wallet_owner_exist(self, wallet_owner: Address):
         if wallet_owner not in self._wallet_owners:
-            self.revert(f"{wallet_owner} is not an owner of wallet")
+            revert(f"{wallet_owner} is not an owner of wallet")
 
     def _transaction_exists(self, transaction_id: int):
         if self._transactions[transaction_id] is None \
                 or self._transaction_count.get() <= transaction_id:
-            self.revert(f"transaction id '{transaction_id}' is not exist")
+            revert(f"transaction id '{transaction_id}' is not exist")
 
     def _confirmed(self, transaction_id: int, wallet_owner: Address):
         if not self._confirmations[transaction_id][wallet_owner]:
-            self.revert(f"{wallet_owner} hasn't confirmed to transaction id '{transaction_id}' yet")
+            revert(f"{wallet_owner} has not confirmed to transaction id '{transaction_id}' yet")
 
     def _not_confirmed(self, transaction_id: int, wallet_owner: Address):
         if self._confirmations[transaction_id][wallet_owner]:
-            self.revert(f"{wallet_owner} has already confirmed to transaction '{transaction_id}'")
+            revert(f"{wallet_owner} has already confirmed to transaction '{transaction_id}'")
 
     def _not_executed(self, transaction_id: int):
         # before call this method, check if transaction is exists(use transaction_exists method)
         if self._transactions[transaction_id][0] == 1:
-            self.revert(f"transaction id '{transaction_id}' has already been executed")
+            revert(f"transaction id '{transaction_id}' has already been executed")
 
     def _check_requirement(self, wallet_owner_count: int, required: int):
         if wallet_owner_count > self._MAX_WALLET_OWNER_COUNT or \
                 required > wallet_owner_count or \
                 required <= 0 or \
                 wallet_owner_count == 0:
-            self.revert(f"invalid requirement")
+            revert("invalid requirement")
 
     @payable
     def fallback(self):
@@ -157,7 +159,7 @@ class MultiSigWallet(IconScoreBase, IconScoreException):
 
     @external
     def submitTransaction(self, _destination: Address,
-                          _method: str="", _params: str="", _value: int=0, _description: str=""):
+                          _method: str = "", _params: str = "", _value: int = 0, _description: str = ""):
         self._wallet_owner_exist(self.msg.sender)
         # prevent failure of executing transaction caused by 'params' conversion problems
         self._check_params_format_convertible(_params)
@@ -368,7 +370,7 @@ class MultiSigWallet(IconScoreBase, IconScoreException):
         return confirmed_wallet_owners
 
     @external(readonly=True)
-    def getTransactionCount(self, _pending: bool=True, _executed: bool=True) -> int:
+    def getTransactionCount(self, _pending: bool = True, _executed: bool = True) -> int:
         tx_count = 0
         for tx_id in range(self._transaction_count.get()):
             if (_pending and not self._transactions[tx_id][0]) or (_executed and self._transactions[tx_id][0]):
@@ -377,11 +379,11 @@ class MultiSigWallet(IconScoreBase, IconScoreException):
         return tx_count
 
     @external(readonly=True)
-    def getTransactionList(self, _offset: int, _count: int, _pending: bool=True, _executed: bool=True) -> list:
+    def getTransactionList(self, _offset: int, _count: int, _pending: bool = True, _executed: bool = True) -> list:
         self._only_positive_number(_offset, _count)
 
         if _count > self._MAX_DATA_REQUEST_AMOUNT:
-            raise IconScoreException("Requests that exceed the allowed amount")
+            revert("requests that exceed the allowed amount")
 
         transaction_list = []
         total_transaction_count = self._transaction_count.get()

--- a/multisig_wallet/multisig_wallet.py
+++ b/multisig_wallet/multisig_wallet.py
@@ -106,7 +106,7 @@ class MultiSigWallet(IconScoreBase):
             except IconScoreException as e:
                 revert(f"{e}")
             except:
-                revert("can't convert 'params' json data, check the 'params' parameter")
+                revert("can not convert 'params' json data, check the 'params' parameter")
 
     @staticmethod
     def _only_positive_number(*args):
@@ -129,11 +129,11 @@ class MultiSigWallet(IconScoreBase):
 
     def _confirmed(self, transaction_id: int, wallet_owner: Address):
         if not self._confirmations[transaction_id][wallet_owner]:
-            revert(f"{wallet_owner} has not confirmed to transaction id '{transaction_id}' yet")
+            revert(f"{wallet_owner} has not confirmed to the transaction id '{transaction_id}' yet")
 
     def _not_confirmed(self, transaction_id: int, wallet_owner: Address):
         if self._confirmations[transaction_id][wallet_owner]:
-            revert(f"{wallet_owner} has already confirmed to transaction '{transaction_id}'")
+            revert(f"{wallet_owner} has already confirmed to the transaction '{transaction_id}'")
 
     def _not_executed(self, transaction_id: int):
         # before call this method, check if transaction is exists(use transaction_exists method)

--- a/multisig_wallet/qualification_check/qualification_check.py
+++ b/multisig_wallet/qualification_check/qualification_check.py
@@ -24,8 +24,7 @@ def only_wallet(func):
     @wraps(func)
     def __wrapper(calling_obj: object, *args, **kwargs):
         if calling_obj.msg.sender != calling_obj.address:
-            calling_obj.revert(
-                f"{func} method only can be called by wallet SCORE(address: {calling_obj.address})")
+            revert(f"{func} method only can be called by wallet SCORE(address: {calling_obj.address})")
 
         return func(calling_obj, *args, **kwargs)
     return __wrapper

--- a/multisig_wallet/qualification_check/qualification_check.py
+++ b/multisig_wallet/qualification_check/qualification_check.py
@@ -19,7 +19,7 @@ from iconservice import *
 
 def only_wallet(func):
     if not isfunction(func):
-        revert(f"{func} isn't function.")
+        revert(f"{func} is not a function.")
 
     @wraps(func)
     def __wrapper(calling_obj: object, *args, **kwargs):

--- a/multisig_wallet/qualification_check/qualification_check.py
+++ b/multisig_wallet/qualification_check/qualification_check.py
@@ -24,7 +24,7 @@ def only_wallet(func):
     @wraps(func)
     def __wrapper(calling_obj: object, *args, **kwargs):
         if calling_obj.msg.sender != calling_obj.address:
-            revert(f"{func} method only can be called by wallet SCORE(address: {calling_obj.address})")
+            revert(f"{func} method can be called only by the wallet SCORE (address: {calling_obj.address})")
 
         return func(calling_obj, *args, **kwargs)
     return __wrapper

--- a/multisig_wallet/type_converter/type_converter.py
+++ b/multisig_wallet/type_converter/type_converter.py
@@ -30,7 +30,7 @@ def params_type_converter(param_type: str, value: any):
         param = _convert_value_bytes(value)
     else:
         raise IconScoreException(
-            f"{param_type} is not supported type(only int, str, bool, Address, bytes are supported)")
+            f"{param_type} is not supported type (only int, str, bool, Address, bytes are supported)")
     return param
 
 

--- a/tests/test_integrate_read_only.py
+++ b/tests/test_integrate_read_only.py
@@ -16,6 +16,8 @@
 
 import json
 
+from iconservice.base.exception import RevertException
+
 from tests import create_address
 from tests.test_integrate_base import TestIntegrateBase
 from iconservice import IconScoreException, ZERO_SCORE_ADDRESS
@@ -134,10 +136,10 @@ class TestIntegrateReadOnly(TestIntegrateBase):
             }
         }
 
-        expected_massage = "Requests that exceed the allowed amount"
+        expected_massage = "requests that exceed the allowed amount"
         try:
             actual_massage = self._query(query_request)
-        except IconScoreException as e:
+        except RevertException as e:
             actual_massage = e.message
             pass
         self.assertEqual(expected_massage, actual_massage)

--- a/tests/test_integrate_revoke_transaction.py
+++ b/tests/test_integrate_revoke_transaction.py
@@ -85,7 +85,7 @@ class TestIntegrateRevokeTransaction(TestIntegrateBase):
         self._write_precommit_state(prev_block)
         self.assertEqual(False, tx_results[0].status)
 
-        expected_revert_massage = f"{self._owner1} hasn't confirmed to transaction id '0' yet"
+        expected_revert_massage = f"{self._owner1} has not confirmed to transaction id '0' yet"
         actual_revert_massage = tx_results[0].failure.message
         self.assertEqual(expected_revert_massage, actual_revert_massage)
 

--- a/tests/test_integrate_revoke_transaction.py
+++ b/tests/test_integrate_revoke_transaction.py
@@ -85,7 +85,7 @@ class TestIntegrateRevokeTransaction(TestIntegrateBase):
         self._write_precommit_state(prev_block)
         self.assertEqual(False, tx_results[0].status)
 
-        expected_revert_massage = f"{self._owner1} has not confirmed to transaction id '0' yet"
+        expected_revert_massage = f"{self._owner1} has not confirmed to the transaction id '0' yet"
         actual_revert_massage = tx_results[0].failure.message
         self.assertEqual(expected_revert_massage, actual_revert_massage)
 

--- a/tests/test_integrate_submit_transaction.py
+++ b/tests/test_integrate_submit_transaction.py
@@ -126,7 +126,7 @@ class TestIntegrateSubmitTransaction(TestIntegrateBase):
         prev_block, tx_results = self._make_and_req_block([valid_tx])
         self._write_precommit_state(prev_block)
 
-        expected_revert_massage = "can't convert 'params' json data, check the 'params' parameter"
+        expected_revert_massage = "can not convert 'params' json data, check the 'params' parameter"
         actual_revert_massage = tx_results[0].failure.message
         self.assertEqual(expected_revert_massage, actual_revert_massage)
 

--- a/tests/test_integrate_submit_transaction.py
+++ b/tests/test_integrate_submit_transaction.py
@@ -106,7 +106,7 @@ class TestIntegrateSubmitTransaction(TestIntegrateBase):
         prev_block, tx_results = self._make_and_req_block([valid_tx])
         self._write_precommit_state(prev_block)
         expected_revert_massage = \
-            "dict is not supported type(only int, str, bool, Address, bytes are supported) (32000)"
+            "dict is not supported type (only int, str, bool, Address, bytes are supported) (32000)"
         actual_revert_massage = tx_results[0].failure.message
         self.assertEqual(expected_revert_massage, actual_revert_massage)
 


### PR DESCRIPTION
1. Supplement the contents of the document
Supplement the contents of the 'submitTransaction' method's parameters

2. Unify the exception codes
self.revert & IconScoreException -> revert
* type converter's Exception still remain 'raise IconScoreException' (there is 'try-catch' issue)

3. Modify an exception messages

after this branch being merged, change the version from '0.9.0' to '0.9.1'